### PR TITLE
Fix a typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add the following code in bootstrap.php
 
 #### file ####
 
-Or, put app/tmp/maintanance file.
+Or, put app/tmp/maintenance file.
 
 ### Timer ###
 


### PR DESCRIPTION
The README was referencing a app/tmp/maintanance but should be app/tmp/maintenance.
