### PR TITLE
Adapted to reverse proxy like load balancer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea/
+/vendor/*

--- a/README.md
+++ b/README.md
@@ -46,3 +46,26 @@ touch tmp/maintenance
 ```
 
 ## Config
+### useXForwardedFor
+
+If your system is behind a reverse proxy like load balancer that adds X-Forwarded-For header, set useXForwardedFor as true.
+
+```php
+// src/Application.php
+use Maintenance\Middleware\MaintenanceMiddleware;
+
+    public function middleware($middleware)
+    {
+        $middleware
+            ->add(new MaintenanceMiddleware([
+                'allowIp' => [
+                    '127.0.0.1',
+                ],
+                'useXForwardedFor' => true,
+            ]))
+            ->add(ErrorHandlerMiddleware::class)
+            ->add(AssetMiddleware::class)
+            ->add(RoutingMiddleware::class);
+        return $middleware;
+    }
+```

--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -106,7 +106,7 @@ class MaintenanceMiddleware
             $ips = explode(',', $params['HTTP_X_FORWARDED_FOR']);
             return trim(array_pop($ips));
         } else {
-            return is_set($params['REMOTE_ADDR']) ? $params['REMOTE_ADDR'] : null;
+            return isset($params['REMOTE_ADDR']) ? $params['REMOTE_ADDR'] : null;
         }
     }
 

--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -106,14 +106,16 @@ class MaintenanceMiddleware
             $ips = explode(',', $params['HTTP_X_FORWARDED_FOR']);
             return trim(array_pop($ips));
         } else {
-            return $params['REMOTE_ADDR'];
+            return is_set($params['REMOTE_ADDR']) ? $params['REMOTE_ADDR'] : null;
         }
     }
 
     private function isAllowIp($request)
     {
-        $params = $request->getServerParams();
         $myIpAddress = $this->getMyIpAddress($request);
+        if (is_null($myIpAddress)) {
+            return false;
+        }
 
         $ipAddressList = $this->config('allowIp');
         if (empty($ipAddressList)) {


### PR DESCRIPTION
ロードバランサ 配下の場合、REMOTE_ADDRがロードバランサ のIPになってしまうので、X-Forwarded-Forを取得しチェックするようにしてみました。