### PR TITLE
upgraded some lines according to cakephp3.5 migration guide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": ">=3.3.2 <4.0.0"
+        "cakephp/cakephp": ">=3.4.0 <4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -35,7 +35,7 @@ class MaintenanceMiddleware
 
     public function __construct($config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     public function __invoke($request, $response, $next)
@@ -56,12 +56,12 @@ class MaintenanceMiddleware
         $cakeRequest = Request::createFromGlobals();
         $builder = new ViewBuilder();
 
-        $className = $this->config('className');
-        $templateName = $this->config('ctpFileName');
-        $templatePath = $this->config('templatePath');
-        $ext = $this->config('ctpExtension');
-        $contentType = $this->config('contentType');
-        $statusCode = $this->config('statusCode');
+        $className = $this->getConfig('className');
+        $templateName = $this->getConfig('ctpFileName');
+        $templatePath = $this->getConfig('templatePath');
+        $ext = $this->getConfig('ctpExtension');
+        $contentType = $this->getConfig('contentType');
+        $statusCode = $this->getConfig('statusCode');
 
         $view = $builder
             ->className($className)
@@ -123,7 +123,7 @@ class MaintenanceMiddleware
         $params = $request->getServerParams();
 
         // X-Forwarded-Forはカンマ区切り。一番近いReverse proxyで付与されたIPを末尾から取得する。
-        if ($this->config('useXForwardedFor') && isset($params['HTTP_X_FORWARDED_FOR'])) {
+        if ($this->getConfig('useXForwardedFor') && isset($params['HTTP_X_FORWARDED_FOR'])) {
             $ips = explode(',', $params['HTTP_X_FORWARDED_FOR']);
             return trim(array_pop($ips));
         } else {


### PR DESCRIPTION
In CakePHP project, many functions and properties were deprecated, and it hurt this plugin, too.
I fixed some codes according to the migration guide

https://book.cakephp.org/3.0/en/appendices/3-5-migration-guide.html
Mainly, I fixed 3 types of codes.

config()
fixed config() function to getConfig()/setConfig() function, respectively.